### PR TITLE
Allow for the mock login plugin

### DIFF
--- a/gulp/db.js
+++ b/gulp/db.js
@@ -1,8 +1,6 @@
 const gulp = require('gulp');
-const Knex = require('knex');
 const shell = require('gulp-shell');
 const Promise = require('bluebird');
-const config = require('../../../../gulp/config');
 
 gulp.task('redis:clearcache', () => {
   Promise.promisifyAll(require('redis'));
@@ -26,7 +24,7 @@ gulp.task('db:reset', shell.task([
   `psql -U flo -d  ${nodeConfig.DATABASE_NAME} -c '\\i src/node/db/db_structuredata.sql'`,
 ]));
 
-gulp.task('db:seed', ['build:backend'], (done) => {
+gulp.task('db:seed', ['build:backend', 'db:reset'], (done) => {
   const Progress = require('progress');
   const services = require('../../services');
   services.initialize();

--- a/mockLogin.js
+++ b/mockLogin.js
@@ -11,13 +11,3 @@ function setToken(user) {
     });
   });
 }
-
-function mockHandler(req, reply) {
-  return User.forge({id: 1})
-  .fetch()
-  .then((u) => {
-    return setToken(u);
-  }).then((t) => {
-    return reply.view('token', {token: t});
-  });
-}

--- a/modules.js
+++ b/modules.js
@@ -1,6 +1,41 @@
+const setToken = require('../controllers/authenticationPlugins/common').setToken;
+
+function mockHandler(req, reply) {
+  return User.forge({id: 1})
+  .fetch()
+  .then((u) => {
+    return setToken(u);
+  }).then((t) => {
+    return reply.view('token', {token: t});
+  });
+}
+
+
+function plugin(server, options, next) {
+  server.route([{
+    method: 'GET',
+    path: `/auth/mock/login`,
+    config: {
+      handler: loginHandler,
+    },
+  }]);
+  next();
+}
+
+plugin.attributes = {
+  name: 'mockDB routing',
+  version: '1.0.0',
+}
+
 module.exports = {
-  login: ['google'],
+  authentication: [
+    {
+      type: 'mock',
+      support: ['login'],
+    },
+  ],
   mailPass: [{
     deny: 'all',
   }],
+  plugins: [plugin],
 };

--- a/modules.js
+++ b/modules.js
@@ -1,4 +1,5 @@
 const setToken = require('../controllers/authenticationPlugins/common').setToken;
+const User = require('../models/user');
 
 function mockHandler(req, reply) {
   return User.forge({id: 1})
@@ -14,9 +15,9 @@ function mockHandler(req, reply) {
 function plugin(server, options, next) {
   server.route([{
     method: 'GET',
-    path: `/auth/mock/login`,
+    path: '/auth/mock/login',
     config: {
-      handler: loginHandler,
+      handler: mockHandler,
     },
   }]);
   next();
@@ -25,13 +26,14 @@ function plugin(server, options, next) {
 plugin.attributes = {
   name: 'mockDB routing',
   version: '1.0.0',
-}
+};
 
 module.exports = {
   authentication: [
     {
       type: 'mock',
       support: ['login'],
+      flags: ['noroutes'],
     },
   ],
   mailPass: [{


### PR DESCRIPTION
With this setup, you do a gulp db:seed, which creates and seeds a randomized database. The "log in with mock credentials" button in the interface logs you in as whoever is user 1. This is obviously not for production use, but gives us a chance to poke at test databases without needing a real login. That's why the mock code is actually here in this config, to make it very difficult to accidentally expose this functionality in production.
